### PR TITLE
Fixes for X11 build (Linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,40 @@ I'll add more info here soon, this is still a work in progress and likely to cha
 
 # License
 The source code for the module is released under unlicense (see license file), note that the related products used, hidapi, libusb, openhmd and Godot itself all have their own licenses.
+
+# Install
+
+## X11 (Linux)
+
+Clone this repository using `git clone --recursive` so all the needed packages will be cloned together with the source code. 
+
+After that build libusb, openhmd and hidapi, using the following commands: 
+
+```
+cd libusb ; ./bootstrap.sh ; ./configure ; make ; cd ..
+cd hidapi ; ./bootstrap ; ./configure ; make ; cd ..
+cd OpenHMD ; ./autogen.sh ; ./configure ; make ; cd ..
+```
+
+To make things easier, set the `GODOT_ROOT` environment variable with the folder that holds the GODOT source code, for example, like this: 
+
+```
+export GODOT_ROOT=../godot.git
+```
+
+The you can build by issuing the followin command: 
+
+```GODOT_HEADERS=$GODOT_ROOT/modules/gdnative/include/  /bin/scons```
+
+Last, you can test your build by issuing:
+
+`$GODOT_ROOT/bin/godot.x11.tools.64 demo/project.godot`
+
+ or
+ 
+`godot demo/project.godot`
+
+## Windows
+
+## OSX
+

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Clone this repository using `git clone --recursive` so all the needed packages w
 After that build libusb, openhmd and hidapi, using the following commands: 
 
 ```
-cd libusb ; ./bootstrap.sh ; ./configure ; make ; cd ..
-cd hidapi ; ./bootstrap ; ./configure ; make ; cd ..
-cd OpenHMD ; ./autogen.sh ; ./configure ; make ; cd ..
+export CORES=$(grep processor /proc/cpuinfo | wc -l)
+cd libusb ; ./bootstrap.sh ; ./configure ; make -j $CORES ; cd ..
+cd hidapi ; ./bootstrap ; ./configure ; make -j $CORES ; cd ..
+cd OpenHMD ; ./autogen.sh ; ./configure ; make -j $CORES ; cd ..
 ```
 
 To make things easier, set the `GODOT_ROOT` environment variable with the folder that holds the GODOT source code, for example, like this: 
@@ -27,7 +28,7 @@ export GODOT_ROOT=../godot.git
 
 The you can build by issuing the followin command: 
 
-```GODOT_HEADERS=$GODOT_ROOT/modules/gdnative/include/  /bin/scons```
+```GODOT_HEADERS=$GODOT_ROOT/modules/gdnative/include/  /bin/scons -j $CORES```
 
 Last, you can test your build by issuing:
 

--- a/SConstruct
+++ b/SConstruct
@@ -6,7 +6,7 @@ godot_glad_path = ARGUMENTS.get("headers", "glad")
 godot_headers_path = ARGUMENTS.get("headers", os.getenv("GODOT_HEADERS", "godot_headers/"))
 libusb_path = ARGUMENTS.get("libusb", os.getenv("LIBUSB_PATH", "libusb/"))
 hidapi_path = ARGUMENTS.get("hidapi", os.getenv("HIDAPI_PATH", "hidapi/"))
-openhmd_path = ARGUMENTS.get("openhmd", os.getenv("OPENHMD_PATH", "openhmd/"))
+openhmd_path = ARGUMENTS.get("openhmd", os.getenv("OPENHMD_PATH", "OpenHMD/"))
 
 target = ARGUMENTS.get("target", "debug")
 
@@ -56,11 +56,12 @@ if platform == "windows":
 
 ####################################################################################################################################
 # Link in glad
-sources.append(godot_glad_path + "\glad.c")
+sources.append(godot_glad_path + "/glad.c")
 
 ####################################################################################################################################
 # Link in libusb, but for now just for linux
 if platform == 'linux':
+    env.Append(CPPPATH=[libusb_path])
     env.Append(CPPPATH=[libusb_path + "libusb"])
     env.Append(CPPPATH=[libusb_path + "libusb/os"])
 


### PR DESCRIPTION
As posix filesystems are usually case-sensitive, I've fixed openhmd to OpenHMD in the SConstruct file. 
Fixed a "\" by a "/", so all plataforms interpret it as a path separation. (linux doesn't like "\")
Added libusb folder in the include search path, since config.h resides there and not in libusb/libusb (it is created after properly making libusb)
Added some INSTALL information to README file to help others build it in X11 systems, specially to properly clone the dependencies and build then. (Without it, build will fail to find libusb config.h in Linux)