### PR TITLE
Remove godot_header environment variable check

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3,7 +3,7 @@ import os, subprocess
 
 # Local dependency paths, adapt them to your setup
 godot_glad_path = ARGUMENTS.get("headers", "glad")
-godot_headers_path = ARGUMENTS.get("headers", os.getenv("GODOT_HEADERS", "godot_headers/"))
+godot_headers_path = ARGUMENTS.get("headers", "godot_headers/")
 libusb_path = ARGUMENTS.get("libusb", os.getenv("LIBUSB_PATH", "libusb/"))
 hidapi_path = ARGUMENTS.get("hidapi", os.getenv("HIDAPI_PATH", "hidapi/"))
 openhmd_path = ARGUMENTS.get("openhmd", os.getenv("OPENHMD_PATH", "OpenHMD/"))


### PR DESCRIPTION
This was a left over from when this module was in a separate folder. Now that we have godot_headers as a submodule there is no need to override this in this way. Its even questionable if we need to check for a command line override.  The changes of the environment variable pointing to an old version has proven to be very likely..